### PR TITLE
Update services Yuka and Instagram to remove blinking

### DIFF
--- a/declarations/Instagram.filters.js
+++ b/declarations/Instagram.filters.js
@@ -1,1 +1,9 @@
 export { cleanUrls } from './Facebook.filters.js';
+
+export const replaceInfoImageWithEmoji = (document) => {
+  const infoImages = document.querySelectorAll('img[src*="/851547_537948159656190_540847388_n.png?"]');
+
+  infoImages.forEach(infoImage => {
+    infoImage.replaceWith('ℹ️')
+  });
+}

--- a/declarations/Instagram.history.json
+++ b/declarations/Instagram.history.json
@@ -4,6 +4,15 @@
       "fetch": "https://developers.facebook.com/terms?locale=en_GB",
       "select": "#faq-page",
       "validUntil": "2021-03-15T22:31:32+04:00"
+    },
+    {
+      "fetch": "https://developers.facebook.com/terms",
+      "select": [
+        "[role='main'] > div > div > div:nth-child(2)",
+        "[role='main'] > div > div > div em"
+      ],
+      "filter": ["cleanUrls"],
+      "validUntil": "2021-11-04T21:16:28.000Z"
     }
   ],
   "Law Enforcement Guidelines": [

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -30,7 +30,7 @@
         "[role='main'] > div > div > div:nth-child(2)",
         "[role='main'] > div > div > div em"
       ],
-      "filter": ["cleanUrls"]
+      "filter": ["cleanUrls", "replaceInfoImageWithEmoji"]
     }
   }
 }

--- a/declarations/Yuka.filters.js
+++ b/declarations/Yuka.filters.js
@@ -1,0 +1,8 @@
+export const replaceDaysAgo = (document) => {
+  const modifiedDate = document.querySelector('meta[property="article:modified_time"]');
+  
+  const updatedTimeContainer = document.querySelector("h1+div > img+div");
+  if (modifiedDate && updatedTimeContainer) {
+    updatedTimeContainer.innerHTML = updatedTimeContainer.innerHTML.replace(/Updated(.*)( by.*)/,`Updated ${modifiedDate.content}$2`)
+  }
+}

--- a/declarations/Yuka.history.json
+++ b/declarations/Yuka.history.json
@@ -1,0 +1,10 @@
+{
+  "Terms of Service": [
+    {
+      "fetch": "https://help.yuka.io/l/en/article/2a12869y56",
+      "select": [".max-w-3xl"],
+      "remove": ["#feedback"],
+      "validUntil": "2021-10-27T07:06:28.000Z"
+    }
+  ]
+}

--- a/declarations/Yuka.json
+++ b/declarations/Yuka.json
@@ -3,8 +3,9 @@
   "documents": {
     "Terms of Service": {
       "fetch": "https://help.yuka.io/l/en/article/2a12869y56",
-      "select": [".max-w-3xl"],
-      "remove": ["#feedback"]
+      "select": [".max-w-3xl", ".justify-start"],
+      "remove": ["#feedback"],
+      "filter": ["replaceDaysAgo"]
     }
   }
 }


### PR DESCRIPTION
Fixes #225 and instagram blinking was not yet mentioned as an issue.

I chose to replace the "days ago" by the real date of last modified taken from page metadata, but I'm not sure this should be the way to go.

So feel free to tell me so