### PR TITLE
Deploy continuously

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,4 +19,4 @@ jobs:
       - run: echo "${{ secrets.ANSIBLE_VAULT_KEY }}" > vault.key
       - run: pip install --upgrade setuptools
       - run: pip install 'ansible ~= 2.9'
-      - run: ansible-playbook ops/app.yml --inventory ops/inventories/production.yml --tags update-declarations
+      - run: ansible-playbook ops/app.yml --inventory ops/inventories/production.yml --tags update-declarations --limit services_all


### PR DESCRIPTION
Following https://github.com/ambanum/OpenTermsArchive/issues/735, the current CD system would deploy all instances, which luckily fails because the server fingerprints are not all listed.

I added the `--limit` option, which did have the expected impact except that it [initially failed](https://github.com/OpenTermsArchive/services-all/actions/runs/1813906414/attempts/1), then updated the server fingerprint for known hosts in the `SERVER_FINGERPRINT` which [succeeded](https://github.com/OpenTermsArchive/services-all/runs/5113931965?check_suite_focus=true).