### PR TITLE
Add missing filters history file for Instagram

### DIFF
--- a/declarations/Instagram.filters.history.js
+++ b/declarations/Instagram.filters.history.js
@@ -1,0 +1,9 @@
+import { cleanUrls as facebookCleanUrls } from './Facebook.filters.js'
+
+
+export const cleanUrls = [
+  {
+    validUntil: "2022-02-23T13:35:03+01:00",
+    filter: facebookCleanUrls
+  }
+];


### PR DESCRIPTION
Necesary after fix of Core.

these tests errors were silently ignored